### PR TITLE
Update courier dependency to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project attempts to follow [Semantic Versioning](http://semver.org/spec
 
 ## Unreleased
 
+### Removed
+
+* Dropped support for Courier 0.4 and 0.5
+
+### Changed
+
+* Added support for Courier 0.6
+
 ## 0.2.0 - 2018-12-12
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.1",
         "psr/log": "^1.0",
-        "quartzy/courier": "^0.4.0|^0.5.0",
+        "quartzy/courier": "^0.6.0",
         "sendgrid/sendgrid": "^7.0",
         "sendgrid/php-http-client": "^3.9.3"
     },

--- a/src/SendGridCourier.php
+++ b/src/SendGridCourier.php
@@ -63,10 +63,6 @@ class SendGridCourier implements ConfirmingCourier
         $mail = $this->prepareEmail($email);
 
         switch (true) {
-            case $email->getContent() instanceof Content\EmptyContent:
-                $response = $this->sendEmptyContent($mail);
-                break;
-
             case $email->getContent() instanceof Content\Contracts\SimpleContent:
                 $response = $this->sendSimpleContent($mail, $email->getContent());
                 break;
@@ -106,7 +102,6 @@ class SendGridCourier implements ConfirmingCourier
     protected function supportedContent(): array
     {
         return [
-            Content\EmptyContent::class,
             Content\Contracts\SimpleContent::class,
             Content\Contracts\TemplatedContent::class,
         ];
@@ -234,18 +229,6 @@ class SendGridCourier implements ConfirmingCourier
         } catch (Exception $e) {
             throw new TransmissionException($e->getCode(), $e);
         }
-    }
-
-    /**
-     * @param Mail $email
-     *
-     * @return SendGrid\Response
-     */
-    protected function sendEmptyContent(Mail $email): SendGrid\Response
-    {
-        $email->addContent(new SendGrid\Mail\PlainTextContent(''));
-
-        return $this->send($email);
     }
 
     /**

--- a/tests/SendGridCourierTest.php
+++ b/tests/SendGridCourierTest.php
@@ -12,7 +12,6 @@ use Exception;
 use Mockery;
 use PhpEmail\Address;
 use PhpEmail\Attachment\FileAttachment;
-use PhpEmail\Content\EmptyContent;
 use PhpEmail\Content\SimpleContent;
 use PhpEmail\Content\TemplatedContent;
 use PhpEmail\Email;
@@ -142,7 +141,7 @@ class SendGridCourierTest extends TestCase
 
         $email = new Email(
             'Subject',
-            new EmptyContent(),
+            SimpleContent::text(''),
             new Address('sender@test.com'),
             [new Address('recipient@test.com')]
         );
@@ -296,7 +295,7 @@ class SendGridCourierTest extends TestCase
 
         $email = new Email(
             'Subject',
-            new EmptyContent(),
+            SimpleContent::text(''),
             new Address('sender@test.com'),
             [new Address('recipient@test.com')]
         );
@@ -323,7 +322,7 @@ class SendGridCourierTest extends TestCase
 
         $email = new Email(
             'Subject',
-            new EmptyContent(),
+            SimpleContent::text(''),
             new Address('sender@test.com'),
             [new Address('recipient@test.com')]
         );
@@ -350,7 +349,7 @@ class SendGridCourierTest extends TestCase
 
         $email = new Email(
             'Subject',
-            new EmptyContent(),
+            SimpleContent::text(''),
             new Address('sender@test.com'),
             [new Address('recipient@test.com')]
         );


### PR DESCRIPTION
This update requires removing references to the EmptyContent type as
well as ensuring the courier can deliver a templated email with a null
subject. SendGrid will accept the null and convert it to an empty string
in templated subjects.